### PR TITLE
Addition of cookie management and proxy

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/transport/ServiceConnection.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/ServiceConnection.java
@@ -23,6 +23,9 @@ package org.ksoap2.transport;
 
 import java.io.*;
 
+import org.apache.http.cookie.MalformedCookieException;
+import org.ksoap2.cookiemanagement.*;
+
 /**
  * Interface to allow the abstraction of the raw transport information
  */
@@ -62,6 +65,31 @@ public interface ServiceConnection {
      * @exception IOException
      */
     public void setRequestMethod(String requestMethodType) throws IOException;
+    
+    /**
+     * Offers the caller an opportunity to extract any cookies that the web
+     * service sent with its response. These are typically used for session
+     * management.
+     * 
+     * @param cookieJar
+     * 			the collection of cookies to which the new cookies will
+     * 			be added or cookies of the same name will be replaced.
+     * @return Collection of cookies encapsulated in a <code>CookieJar</code>.
+     * @throws MalformedCookieException 
+     * 			Bad cookie was found in the data returned by the web server.
+     */
+    public CookieJar saveCookies(CookieJar cookieJar);
+    
+    /**
+     * Offers the caller an opportunity to send cookies to the web service.
+     * Typically these would be session cookies that were returned by another
+     * method of the same web service. 
+     * This method must be called before the connection has been made.
+     * 
+     * @param cookieJar
+     * 				the collection of cookies to send.
+     */
+    public void sendCookies(CookieJar cookieJar);
 
     /**
      * Open and return the outputStream to the endpoint.

--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -24,6 +24,7 @@
 package org.ksoap2.transport;
 
 import java.io.*;
+import java.net.Proxy;
 
 import org.ksoap2.*;
 import org.kxml2.io.*;
@@ -37,6 +38,12 @@ import org.xmlpull.v1.*;
  */
 abstract public class Transport {
 
+	/** 
+	 * Added to enable web service interactions on the emulator 
+	 * to be debugged with Fiddler2 (Windows) but provides utility 
+	 * for other proxy requirements.
+	 */
+	protected Proxy proxy;
     protected String url;
     /** Set to true if debugging */
     public boolean debug;
@@ -50,6 +57,19 @@ abstract public class Transport {
     }
 
     public Transport(String url) {
+		this(null, url);
+    }
+    
+    /**
+     * Construct the transport object
+     * 
+     * @param proxy Specifies the proxy server to use for 
+     * accessing the web service or <code>null</code> if a direct connection is available
+     * @param url Specifies the web service url
+     * 
+     */
+    public Transport(Proxy proxy, String url) {
+    	this.proxy = proxy;
         this.url = url;
     }
 

--- a/ksoap2-cookiemanagement/src/main/java/org/ksoap2/cookiemanagement/CookieJar.java
+++ b/ksoap2-cookiemanagement/src/main/java/org/ksoap2/cookiemanagement/CookieJar.java
@@ -1,0 +1,116 @@
+package org.ksoap2.cookiemanagement;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.http.Header;
+import org.apache.http.cookie.Cookie;
+import org.apache.http.cookie.CookieOrigin;
+import org.apache.http.cookie.CookieSpec;
+import org.apache.http.cookie.MalformedCookieException;
+import org.apache.http.impl.cookie.BestMatchSpec;
+
+import android.util.Log;
+
+public class CookieJar {
+	
+	private static final String TAG = "COOKIEJAR";
+	
+	private Map<String, Cookie> _cookieMap;
+	private CookieSpec _spec = new BestMatchSpec();
+	
+	public CookieJar() {
+		_cookieMap = new HashMap<String, Cookie>();
+	}
+	
+	public CookieJar(Map<String, Cookie> cookieMap) {
+
+		if (cookieMap == null)
+			throw new IllegalArgumentException("Cookie Map cannot be null");
+
+		_cookieMap = cookieMap; 
+	}
+	
+	public void saveCookies(Header header, CookieOrigin origin) {
+		
+		if (origin == null)
+			throw new IllegalArgumentException("CookieOrigin cannot be null");
+		
+		if (header == null) 
+			throw new IllegalArgumentException("Header cannot be null");
+		
+		List<Cookie> cookies;
+		String key;
+		
+		try {
+			
+			// Parse the cookies (typically just one)
+			cookies = _spec.parse(header, origin);
+		} catch (MalformedCookieException e) {
+			
+			// Absorb invalid cookies
+			Log.d(TAG, e.getMessage());
+			return;
+		}
+		
+		for (int i = 0; i < cookies.size(); i++) {
+			
+			try {
+				Cookie cookie = cookies.get(i);
+				
+				// Check if the cookie is valid
+				_spec.validate(cookie, origin);
+				
+				// Cookie is valid - save it
+				key = cookie.getDomain() + "$" + cookie.getPath() + "$" + cookie.getName();
+				
+				// Remove any previous cookie with the same key. This allows the web server
+				// to replace a cookie or delete a cookie by replacing it with one that has
+				// expired
+				_cookieMap.remove(key);
+				
+				// Save the new cookie
+				_cookieMap.put(key, cookie);
+			} catch (MalformedCookieException e) {
+				
+				// Remove invalid cookie
+				cookies.remove(i);
+			}
+		}
+	}
+	
+	public List<Header> sendCookies(CookieOrigin origin) {
+		
+		if (origin == null)
+			throw new IllegalArgumentException("CookieOrigin cannot be null");
+		
+		List<Cookie> cookiesToSend = new LinkedList<Cookie>();
+		Set<String> keys = _cookieMap.keySet();
+		Date now = new Date();
+		
+		for (Iterator<String> i = keys.iterator(); i.hasNext();) {
+			
+			String key = i.next();
+			Cookie cookie = _cookieMap.get(key);
+			
+			if (cookie.isExpired(now) == true) {
+				_cookieMap.remove(key);
+			}
+			else if (_spec.match(cookie, origin)) {
+				cookiesToSend.add(cookie);
+			}
+		}
+		
+		// formatCookies will throw an exception if the list is empty
+		return (cookiesToSend.size() > 0)? _spec.formatCookies(cookiesToSend) : new LinkedList<Header>();
+	}
+	
+	public List<Cookie> getCookies() {
+		return new LinkedList<Cookie>(_cookieMap.values());
+	}
+}

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -25,9 +25,12 @@
 package org.ksoap2.transport;
 
 import java.io.*;
+import java.net.Proxy;
 
 import org.ksoap2.*;
 import org.xmlpull.v1.*;
+
+import org.ksoap2.cookiemanagement.*;
 
 /**
  * A J2SE based HttpTransport layer.
@@ -43,7 +46,20 @@ public class HttpTransportSE extends Transport {
      *            the destination to POST SOAP data
      */
     public HttpTransportSE(String url) {
-        super(url);
+        super(null, url);
+    }
+    
+    /**
+     * Creates instance of HttpTransportSE with set url and defines a
+     * proxy server to use to access it
+     * 
+     * @param proxy
+     * 				Proxy information or <code>null</code> for direct access
+     * @param url
+     * 				The destination to POST SOAP data
+     */
+    public HttpTransportSE(Proxy proxy, String url) {
+    	super(proxy, url);
     }
 
     /**
@@ -53,65 +69,103 @@ public class HttpTransportSE extends Transport {
      *            the desired soapAction
      * @param envelope
      *            the envelope containing the information for the soap call.
+     * @throws MalformedCookieException 
      */
     public void call(String soapAction, SoapEnvelope envelope) throws IOException, XmlPullParserException {
-        if (soapAction == null)
-            soapAction = "\"\"";
-        byte[] requestData = createRequestData(envelope);
-        requestDump = debug ? new String(requestData) : null;
-        responseDump = null;
-        connection = getServiceConnection();
-        connection.setRequestProperty("User-Agent", "kSOAP/2.0");
-        connection.setRequestProperty("SOAPAction", soapAction);
-        connection.setRequestProperty("Content-Type", "text/xml");
-        connection.setRequestProperty("Connection", "close");
-        connection.setRequestProperty("Content-Length", "" + requestData.length);
-        connection.setRequestMethod("POST");
-        connection.connect();
-        OutputStream os = connection.openOutputStream();
-        os.write(requestData, 0, requestData.length);
-        os.flush();
-        os.close();
-        requestData = null;
-        InputStream is;
-        try {
-            connection.connect();
-            is = connection.openInputStream();
-        } catch (IOException e) {
-            is = connection.getErrorStream();
-            if (is == null) {
-                connection.disconnect();
-                throw (e);
-            }
-        }
-        if (debug) {
-            ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            byte[] buf = new byte[256];
-            while (true) {
-                int rd = is.read(buf, 0, 256);
-                if (rd == -1)
-                    break;
-                bos.write(buf, 0, rd);
-            }
-            bos.flush();
-            buf = bos.toByteArray();
-            responseDump = new String(buf);
-            is.close();
-            is = new ByteArrayInputStream(buf);
-        }
-        parseResponse(envelope, is);
+    	
+    	call(soapAction, envelope, null);
     }
 
-    /**
-	 * Returns the HttpsServiceConnectionSE that was created in getServiceConnection or null
-	 * if getServiceConnection was not called or failed.
-	 * @return ServiceConnection
+	/**
+	 * 
+     * set the desired soapAction header field
+     * 
+     * @param soapAction
+     *            	the desired soapAction
+     * @param envelope
+     *            	the envelope containing the information for the soap call.
+     * @param cookieJar
+     * 				           
+     * @return <code>CookieJar</code> with any cookies sent by the server
+	 * @throws MalformedCookieException Cookie is invalid
 	 */
+    public CookieJar call(String soapAction, SoapEnvelope envelope, CookieJar cookieJar) 
+		throws IOException, XmlPullParserException {
+
+		if (soapAction == null)
+			soapAction = "\"\"";
+
+		byte[] requestData = createRequestData(envelope);
+	    
+		requestDump = debug ? new String(requestData) : null;
+	    responseDump = null;
+	    
+	    connection = getServiceConnection();
+	    
+	    connection.setRequestProperty("User-Agent", "kSOAP/2.0");
+	    connection.setRequestProperty("SOAPAction", soapAction);
+	    connection.setRequestProperty("Content-Type", "text/xml");
+	    connection.setRequestProperty("Connection", "close");
+	    connection.setRequestProperty("Content-Length", "" + requestData.length);
+	    connection.setRequestMethod("POST");
+	    
+	    // Only send cookies if we appear to have some
+	    if (cookieJar != null)
+	    	connection.sendCookies(cookieJar);
+	    
+	    connection.connect();
+    
+
+	    OutputStream os = connection.openOutputStream();
+   
+	    os.write(requestData, 0, requestData.length);
+	    os.flush();
+	    os.close();
+	    requestData = null;
+	    InputStream is;
+	    try {
+	    	connection.connect();
+	    	is = connection.openInputStream();
+	    	
+	    	if (cookieJar != null)
+	    		connection.saveCookies(cookieJar);
+	    	
+	    } catch (IOException e) {
+	    	is = connection.getErrorStream();
+
+	    	if (is == null) {
+	    		connection.disconnect();
+	    		throw (e);
+	    	}
+	    }
+    
+		if (debug) {
+	        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+	        byte[] buf = new byte[256];
+	        
+	        while (true) {
+	            int rd = is.read(buf, 0, 256);
+	            if (rd == -1)
+	                break;
+	            bos.write(buf, 0, rd);
+	        }
+	        
+	        bos.flush();
+	        buf = bos.toByteArray();
+	        responseDump = new String(buf);
+	        is.close();
+	        is = new ByteArrayInputStream(buf);
+	    }
+   
+	    parseResponse(envelope, is);
+	    return cookieJar;
+	}
+
 	public ServiceConnection getConnection() {
 		return (ServiceConnectionSE) connection;
 	}
 
     protected ServiceConnection getServiceConnection() throws IOException {
-        return new ServiceConnectionSE(url);
+        return new ServiceConnectionSE(proxy, url);
     }
 }

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
@@ -31,8 +31,8 @@ public class HttpsTransportSE extends HttpTransportSE{
 	 * if getServiceConnection was not called or failed.
 	 * @return ServiceConnection
 	 */
-    public ServiceConnection getConnection() {
-		return (HttpsServiceConnectionSE) conn;
+	public HttpsServiceConnectionSE getConnection() {
+		return conn;
 	}
 
 	/**

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/ServiceConnectionSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/ServiceConnectionSE.java
@@ -23,6 +23,15 @@ package org.ksoap2.transport;
 
 import java.io.*;
 import java.net.*;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.http.Header;
+import org.apache.http.cookie.CookieOrigin;
+import org.apache.http.message.BasicHeader;
+import org.ksoap2.cookiemanagement.*;
 
 /**
  * Connection for J2SE environments.
@@ -36,7 +45,14 @@ public class ServiceConnectionSE implements ServiceConnection {
      * @param url the url to open the connection to.
      */
     public ServiceConnectionSE(String url) throws IOException {
-        connection = (HttpURLConnection) new URL(url).openConnection();
+    	this(null, url);
+    }
+
+    public ServiceConnectionSE(Proxy proxy, String url) throws IOException {
+    	
+    	connection = (proxy == null)
+    		? (HttpURLConnection) new URL(url).openConnection()
+    		: (HttpURLConnection) new URL(url).openConnection(proxy);
         connection.setUseCaches(false);
         connection.setDoOutput(true);
         connection.setDoInput(true);
@@ -56,6 +72,55 @@ public class ServiceConnectionSE implements ServiceConnection {
 
     public void setRequestMethod(String requestMethod) throws IOException {
         connection.setRequestMethod(requestMethod);
+    }
+
+    @Override
+    public CookieJar saveCookies(CookieJar cookieJar) {
+    	
+		if (cookieJar == null)
+			throw new IllegalArgumentException("CookieJar cannot be null");
+		
+    	Map<String, List<String>> headers = connection.getHeaderFields();
+    	Set<String> keys = headers.keySet();
+    	CookieOrigin origin = new CookieOrigin(
+    			connection.getURL().getHost(), 
+    			connection.getURL().getPort(), 
+    			connection.getURL().getPath(), 
+    			false);
+    	
+    	for (Iterator<String> iter = keys.iterator(); iter.hasNext();) {
+    		String key = iter.next();
+    		
+    		if (key.equalsIgnoreCase("set-cookie") || key.equalsIgnoreCase("set-cookie2")) {
+    			
+    			List<String> values = headers.get(key);
+    			
+    			for (int i = 0; i < values.size(); i++) {
+        			cookieJar.saveCookies(new BasicHeader(key, values.get(i)), origin);
+    			}
+    		}
+    	}
+    	
+    	return cookieJar;
+    }
+    
+    @Override
+    public void sendCookies(CookieJar cookieJar) {
+
+		if (cookieJar == null)
+			throw new IllegalArgumentException("CookieJar cannot be null");
+		
+    	CookieOrigin origin = new CookieOrigin(
+    			connection.getURL().getHost(), 
+    			connection.getURL().getPort(), 
+    			connection.getURL().getPath(), 
+    			true);
+    	List<Header> cookies = cookieJar.sendCookies(origin);
+    	
+    	for (int i = 0; i < cookies.size(); i++) {
+    		Header cookie = cookies.get(i);
+    		connection.addRequestProperty(cookie.getName(), cookie.getValue());
+    	}
     }
 
     public OutputStream openOutputStream() throws IOException {

--- a/ksoap2-midp/src/main/java/org/ksoap2/transport/HttpTransport.java
+++ b/ksoap2-midp/src/main/java/org/ksoap2/transport/HttpTransport.java
@@ -31,6 +31,8 @@ import javax.microedition.io.*;
 import org.ksoap2.*;
 import org.xmlpull.v1.*;
 
+import java.net.Proxy;
+
 /**
  * Methods to facilitate SOAP calls over HTTP using the J2ME generic connection
  * framework.
@@ -117,6 +119,10 @@ public class HttpTransport extends Transport {
      */
     public HttpTransport(String url) {
         super(url);
+    }
+    
+    public HttpTransport(Proxy proxy, String url) {
+    	super(proxy, url);
     }
 
     /**


### PR DESCRIPTION
Added the ability to save and send cookies when they are presented and required by the web service. Typically a web service will send a cookie if it needs to associate the response to this function call with the request of a later function call. For example it could be used to maintain a user identity. .NET SOAP services can be set up to maintain state in this way.
Added the option to use a proxy server to access the web service. I added this in order to debug the web service interactions with Fiddler2 but, since it is conceivable that somebody may need to use a proxy server to access a web service I left the code in.
