### PR TITLE
Fixed bug in getHost/Port/Path

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -26,7 +26,9 @@ package org.ksoap2.transport;
 
 import java.util.List;
 import java.io.*;
+import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.URL;
 
 import org.ksoap2.*;
 import org.xmlpull.v1.*;
@@ -172,14 +174,41 @@ public class HttpTransportSE extends Transport {
     }
 
 	public String getHost() {
-		return connection.getHost();
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getHost();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
     
 	public int getPort() {
-		return connection.getPort();
+		
+		int retVal = -1;
+		
+		try {
+			retVal = new URL(url).getPort();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
     
 	public String getPath() {
-		return connection.getPath();
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getPath();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
 }

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
@@ -1,6 +1,8 @@
 package org.ksoap2.transport;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 /**
  * HttpsTransportSE is a simple transport for https protocal based connections. It creates a #HttpsServiceConnectionSE
@@ -47,14 +49,41 @@ public class HttpsTransportSE extends HttpTransportSE{
 	}
 
 	public String getHost() {
-		return conn.getHost();
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getHost();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
     
 	public int getPort() {
-		return conn.getPort();
+		
+		int retVal = -1;
+		
+		try {
+			retVal = new URL(url).getPort();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
     
 	public String getPath() {
-		return conn.getPath();
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getPath();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
     }
 }

--- a/ksoap2-midp/src/main/java/org/ksoap2/transport/HttpTransport.java
+++ b/ksoap2-midp/src/main/java/org/ksoap2/transport/HttpTransport.java
@@ -32,7 +32,9 @@ import javax.microedition.io.*;
 import org.ksoap2.*;
 import org.xmlpull.v1.*;
 
+import java.net.MalformedURLException;
 import java.net.Proxy;
+import java.net.URL;
 
 /**
  * Methods to facilitate SOAP calls over HTTP using the J2ME generic connection
@@ -223,14 +225,41 @@ public class HttpTransport extends Transport {
     }
 	
 	public String getHost() {
-		return connection.getHost();
-	}
-
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getHost();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
+    }
+    
 	public int getPort() {
-		return connection.getPort();
-	}
-
+		
+		int retVal = -1;
+		
+		try {
+			retVal = new URL(url).getPort();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
+    }
+    
 	public String getPath() {
-		return connection.getPath();
-	}
+		
+		String retVal = null;
+		
+		try {
+			retVal = new URL(url).getPath();
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		}
+		
+		return retVal;
+    }
 }


### PR DESCRIPTION
Fixed a bug in the SE HTTP and HTTPS transports. My test code attempts to acquire the URI origin from the getHost, getPort and getPath calls that I added but these functions assume that the connection has already been created. Typically it will not have been so it will throw an null pointer exception. Modified the methods to extrapolate those values from the URI string that was passed to the constructor.
