### PR TITLE
Fixed namespaces for VER12 to follow the SOAP 1.2 standard.

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/SoapEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/SoapEnvelope.java
@@ -39,8 +39,8 @@ public class SoapEnvelope {
     public static final int VER11 = 110;
     /** SOAP Version 1.2 constant */
     public static final int VER12 = 120;
-    public static final String ENV2001 = "http://www.w3.org/2001/12/soap-envelope";
-    public static final String ENC2001 = "http://www.w3.org/2001/12/soap-encoding";
+    public static final String ENV2003 = "http://www.w3.org/2003/05/soap-envelope";
+    public static final String ENC2003 = "http://www.w3.org/2003/05/soap-encoding";
     /** Namespace constant: http://schemas.xmlsoap.org/soap/envelope/ */
     public static final String ENV = "http://schemas.xmlsoap.org/soap/envelope/";
     /** Namespace constant: http://schemas.xmlsoap.org/soap/encoding/ */
@@ -116,8 +116,8 @@ public class SoapEnvelope {
             enc = SoapEnvelope.ENC;
             env = SoapEnvelope.ENV;
         } else {
-            enc = SoapEnvelope.ENC2001;
-            env = SoapEnvelope.ENV2001;
+            enc = SoapEnvelope.ENC2003;
+            env = SoapEnvelope.ENV2003;
         }
     }
 

--- a/ksoap2-base/src/test/java/org/ksoap2/SoapEnvelopeTest.java
+++ b/ksoap2-base/src/test/java/org/ksoap2/SoapEnvelopeTest.java
@@ -46,8 +46,8 @@ public class SoapEnvelopeTest extends TestCase {
         SoapEnvelope envelope = new SoapEnvelope(SoapEnvelope.VER12);
         assertEquals(SoapEnvelope.XSI, envelope.xsi);
         assertEquals(SoapEnvelope.XSD, envelope.xsd);
-        assertEquals(SoapEnvelope.ENC2001, envelope.enc);
-        assertEquals(SoapEnvelope.ENV2001, envelope.env);
+        assertEquals(SoapEnvelope.ENC2003, envelope.enc);
+        assertEquals(SoapEnvelope.ENV2003, envelope.env);
         assertEquals(SoapEnvelope.VER12, envelope.version);
     }
     


### PR DESCRIPTION
(see http://www.w3.org/TR/soap12-part1/#soapenvelope)

Fixes issue http://code.google.com/p/ksoap2-android/issues/detail?id=68
