### PR TITLE
Solution to Issue 75.

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -714,9 +714,14 @@ public class SoapSerializationEnvelope extends SoapEnvelope
 
 		int cnt = vector.size();
 		Object[] arrType = getInfo(elementType.type, null);
-		// I think that this needs an implicitTypes check, but don't have a failure case for that
-		writer.attribute(enc, ARRAY_TYPE_LABEL, writer.getPrefix((String) arrType[0], false) + ":"
-				+ arrType[1] + "[" + cnt + "]");
+		
+		// This removes the arrayType attribute from the xml for arrays(required for most .Net services to work)
+		if(!implicitTypes)
+		{
+    		     writer.attribute(enc, ARRAY_TYPE_LABEL, writer.getPrefix((String) arrType[0], false) + ":"
+    				+ arrType[1] + "[" + cnt + "]");
+		}
+		
 		boolean skipped = false;
 		for (int i = 0; i < cnt; i++)
 		{
@@ -730,7 +735,9 @@ public class SoapSerializationEnvelope extends SoapEnvelope
 					writer.attribute(enc, "position", "[" + i + "]");
 					skipped = false;
 				}
+								
 				writeProperty(writer, vector.elementAt(i), elementType);
+								
 				writer.endTag(itemsNamespace, itemsTagName);
 			}
 		}


### PR DESCRIPTION
Changed writeVectorBody   added if !implicitTypes block to only add the array type label if they arent using implicit types.  This matches the behavior for all the other data types i've observed.  This should also be the solution to Issue 75:   http://code.google.com/p/ksoap2-android/issues/detail?id=75 
