### PR TITLE
Fix for duplicate calls to connect

### DIFF
--- a/ksoap2-base/src/test/java/org/ksoap2/transport/ServiceConnectionFixture.java
+++ b/ksoap2-base/src/test/java/org/ksoap2/transport/ServiceConnectionFixture.java
@@ -335,6 +335,10 @@ public class ServiceConnectionFixture implements ServiceConnection {
     public ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     public boolean connected;
 
+    public ServiceConnectionFixture() {
+        connected = true;
+    }
+
     public static InputStream hashTableWithDupAsStream() {
         return messsageAsStream(HASH_TABLE_PARAMETERS_DUP);
     }

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -152,7 +152,6 @@ public class HttpTransportSE extends Transport {
         }
             
         connection.setRequestMethod("POST");
-        connection.connect();
         
 
         OutputStream os = connection.openOutputStream();
@@ -165,7 +164,6 @@ public class HttpTransportSE extends Transport {
         List retHeaders = null;
             
         try {
-            connection.connect();
             retHeaders = connection.getResponseProperties();
             boolean gZippedContent = false;
             for (int i = 0; i < retHeaders.size(); i++) {


### PR DESCRIPTION
Hi,

I removed the duplicated calls from HttpTransprtSE, and fixed also the Test Case, there is no need to fix it in 
other transport as HttpsTransportSE as it inherits from the first one.

I Also noted that we are not explicitly closing the connection, but that will be for other pull request as it might need more changes.
