### PR TITLE
Gzip stream workaround for Android 2.3

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -200,7 +200,15 @@ public class HttpTransportSE extends Transport {
                 }
             }
             if (gZippedContent) {
-                is = new GZIPInputStream(connection.openInputStream());
+                /* workaround for Android 2.3 
+                   (see http://stackoverflow.com/questions/5131016/)
+                */
+                InputStream origStream = connection.openInputStream();
+                try {
+                    is = (GZIPInputStream) origStream;
+                } catch (ClassCastException e) {
+                    is = new GZIPInputStream(origStream);
+                }
             } else {
                 is = connection.openInputStream();
             }


### PR DESCRIPTION
Here are the changes to prevent IO exceptions on some Android 2.3 devices. Based on [this discussion](http://stackoverflow.com/questions/5131016/gzipinputstream-fails-with-ioexception-in-android-2-3-but-works-fine-in-all-pre).
