### PR TITLE
SOAP envelope encoding synced with HTTP request Content-Type attribute

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -119,12 +119,12 @@ abstract public class Transport {
     /**
      * Serializes the request.
      */
-    protected byte[] createRequestData(SoapEnvelope envelope) throws IOException {
+    protected byte[] createRequestData(SoapEnvelope envelope, String encoding) throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream(bufferLength);
         byte result[] = null;
         bos.write(xmlVersionTag.getBytes());
         XmlSerializer xw = new KXmlSerializer();
-        xw.setOutput(bos, null);
+        xw.setOutput(bos, encoding);
         envelope.write(xw);
         xw.flush();
         bos.write('\r');
@@ -134,6 +134,12 @@ abstract public class Transport {
         xw = null;
         bos = null;
         return result;
+    }
+    /**
+     * Serializes the request.
+     */
+    protected byte[] createRequestData(SoapEnvelope envelope) throws IOException {
+        return createRequestData(envelope, null);
     }
 
     /**

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -136,7 +136,7 @@ public class HttpTransportSE extends Transport {
             soapAction = "\"\"";
         }
 
-        byte[] requestData = createRequestData(envelope);
+        byte[] requestData = createRequestData(envelope, "UTF-8");
             
         requestDump = debug ? new String(requestData) : null;
         responseDump = null;


### PR DESCRIPTION
SOAP envelope encoding changed to UTF-8.
