### PR TITLE
Added BufferedInputStream to wrap the InputStream

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -113,7 +113,11 @@ abstract public class Transport {
         XmlPullParser xp = new KXmlParser();
         xp.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
         xp.setInput(is, null);
-        envelope.parse(xp);        
+        envelope.parse(xp);  
+        /*
+         * Fix memory leak when running on android in strict mode. Issue 133
+         */
+        is.close();        
     }
 
     /**


### PR DESCRIPTION
I have added a BufferedInputStream to wrap the InputStream for socket while we read data, this will improve the performance considerably while we read data. 

At the end the only changes are in the HttpTransportSE class but i did several movements trying unsuccesfuly to avoid the creation of another copy in memory for the ResponseDump.

This might solve the issue #82
