### PR TITLE
Enhancement : Easier way of getting Http Response Code on Call() when response code != 200

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpResponseException.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpResponseException.java
@@ -3,31 +3,31 @@ package org.ksoap2.transport;
 import java.io.IOException;
 
 /**
- * HttpProtocolException is an IOException that is to be thrown when a Http response code is different from 200.
+ * HttpResponseException is an IOException that is to be thrown when a Http response code is different from 200.
  * It allows for easier retrieval of the Http response code from the connection.
  *
  * @author Rui Pereira <syshex@gmail.com>
  */
-public class HttpProtocolException extends IOException {
+public class HttpResponseException extends IOException {
 
     private int statusCode;
 
-    public HttpProtocolException(int statusCode) {
+    public HttpResponseException(int statusCode) {
         super();
         this.statusCode = statusCode;
     }
 
-    public HttpProtocolException(String detailMessage, int statusCode) {
+    public HttpResponseException(String detailMessage, int statusCode) {
         super(detailMessage);
         this.statusCode = statusCode;
     }
 
-    public HttpProtocolException(String message, Throwable cause, int statusCode) {
+    public HttpResponseException(String message, Throwable cause, int statusCode) {
         super(message, cause);
         this.statusCode = statusCode;
     }
 
-    public HttpProtocolException(Throwable cause, int statusCode) {
+    public HttpResponseException(Throwable cause, int statusCode) {
         super(cause);
         this.statusCode = statusCode;
     }

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -103,16 +103,17 @@ public class HttpTransportSE extends Transport {
      *            the desired soapAction
      * @param envelope
      *            the envelope containing the information for the soap call.
+     * @throws HttpResponseException
      * @throws IOException
      * @throws XmlPullParserException
      */
-    public void call(String soapAction, SoapEnvelope envelope) throws IOException, XmlPullParserException {
+    public void call(String soapAction, SoapEnvelope envelope) throws HttpResponseException, IOException, XmlPullParserException {
             
         call(soapAction, envelope, null);
     }
 
     public List call(String soapAction, SoapEnvelope envelope, List headers)
-            throws IOException, XmlPullParserException {
+            throws HttpResponseException, IOException, XmlPullParserException {
         return call(soapAction, envelope, headers, null);
     }
 
@@ -134,11 +135,11 @@ public class HttpTransportSE extends Transport {
      * @return Headers returned by the web service as a <code>List</code> of
      * <code>HeaderProperty</code> instances.
      *
-     * @throws HttpProtocolException
+     * @throws HttpResponseException
      *              an IOException when Http response code is different from 200
      */
     public List call(String soapAction, SoapEnvelope envelope, List headers, File outputFile)
-        throws HttpProtocolException, IOException, XmlPullParserException {
+        throws HttpResponseException, IOException, XmlPullParserException {
 
         if (soapAction == null) {
             soapAction = "\"\"";
@@ -231,7 +232,7 @@ public class HttpTransportSE extends Transport {
             //first check the response code....
             if (status != 200) {
                 //throw new IOException("HTTP request failed, HTTP status: " + status);
-                throw new HttpProtocolException("HTTP request failed, HTTP status: " + status, status);
+                throw new HttpResponseException("HTTP request failed, HTTP status: " + status, status);
             }
 
             if (gZippedContent) {
@@ -248,14 +249,16 @@ public class HttpTransportSE extends Transport {
                 is = new BufferedInputStream(connection.getErrorStream(),contentLength);
             }
 
-            if (status != 200 && !xmlContent) {
-                if (debug && is != null) {
-                    //go ahead and read the error stream into the debug buffers/file if needed.
-                    readDebug(is, contentLength, outputFile);
-                }
+            if ( e instanceof HttpResponseException) {
+                if (!xmlContent) {
+                    if (debug && is != null) {
+                        //go ahead and read the error stream into the debug buffers/file if needed.
+                        readDebug(is, contentLength, outputFile);
+                    }
 
-                //we never want to drop through to attempting to parse the HTTP error stream as a SOAP response.
-                connection.disconnect();
+                    //we never want to drop through to attempting to parse the HTTP error stream as a SOAP response.
+                    connection.disconnect();
+                }
                 throw e;
             }
         }


### PR DESCRIPTION
When the call() method is called and a response code other than 200 is returned from the server, and IOException was created and throw. 

In order to handle this unexpected response code on the application one would need to parse the IOException String message and also handle the failure to parse the message.

This is basically an enhancement to the call() methods of HttpTransportSE to throw HttpResponseException when http response code != 200  , and therefore allow for handling in an easier fashion on the application side, without the need for parsing and stuff. 

Did this because I need it  and also because on stackoverflow  people have been suggesting doing 2 calls to the webservice to get the response code :  http://stackoverflow.com/questions/10582931/ksoap2-get-http-status-code-for-a-response-of-a-web-service/10583027     
