### PR TITLE
Skip null properties

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -64,6 +64,12 @@ public class SoapSerializationEnvelope extends SoapEnvelope
     public boolean implicitTypes;
 
     /**
+     * If set to true then all properties with null value will be skipped from the soap message.
+     * If false then null properties will be sent as <element nil="true" />
+     */
+    public boolean skipNullProperties;
+
+    /**
      * Set this variable to true for compatibility with what seems to be the default encoding for
      * .Net-Services. This feature is an extremely ugly hack. A much better option is to change the
      * configuration of the .Net-Server to standard Soap Serialization!
@@ -591,9 +597,12 @@ public class SoapSerializationEnvelope extends SoapEnvelope
             if(!(prop instanceof SoapObject)) {
                 // prop is a PropertyInfo
                 if ((propertyInfo.flags & PropertyInfo.TRANSIENT) == 0) {
-                    writer.startTag(propertyInfo.namespace, propertyInfo.name);
-                    writeProperty(writer, obj.getProperty(i), propertyInfo);
-                    writer.endTag(propertyInfo.namespace, propertyInfo.name);
+                    if(prop!=null || !skipNullProperties)
+                    {
+                        writer.startTag(propertyInfo.namespace, propertyInfo.name);
+                        writeProperty(writer, obj.getProperty(i), propertyInfo);
+                        writer.endTag(propertyInfo.namespace, propertyInfo.name);
+                    }
                 }
             } else {
                 // prop is a SoapObject


### PR DESCRIPTION
I'm author of http://easywsdl.com. One of our user has a problem that his webservice throws exception when we sent null property as <property nil="true" />. The solution is to basically skip null properties from soap request. 
My change allows to ksoap2 skip properties with null values from the soap request. This is of course configurable (via skipNullProperties field) and the default value is to use the old behavior (so this change shouldn't break any existing code).
