### PR TITLE
Serialize attributes from any class inherits from AttributeContainer

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/MarshalHashtable.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/MarshalHashtable.java
@@ -80,7 +80,7 @@ public class MarshalHashtable implements Marshal {
             Object key = keys.nextElement();
             item.setProperty(0, key);
             item.setProperty(1, h.get(key));
-            envelope.writeObjectBody(writer, item);
+            envelope.writeObjectBodyWithAttributes(writer, item);
             writer.endTag("", "item");
         }
     }

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -487,7 +487,7 @@ public class SoapSerializationEnvelope extends SoapEnvelope
     public void addMapping(String namespace, String name, Class clazz, Marshal marshal) {
         qNameToClass
                 .put(new SoapPrimitive(namespace, name, null), marshal == null ? (Object) clazz : marshal);
-        classToQName.put(clazz.getName(), new Object[] { namespace, name, null, marshal });
+        classToQName.put(clazz.getName(), new Object[]{namespace, name, null, marshal});
     }
 
     /**
@@ -557,22 +557,24 @@ public class SoapSerializationEnvelope extends SoapEnvelope
         }
     }
 
-    /**
-     * Writes the body of an SoapObject. This method write the attributes and then calls
-     * "writeObjectBody (writer, (KvmSerializable)obj);"
-     */
-    public void writeObjectBody(XmlSerializer writer, SoapObject obj) throws IOException {
-        SoapObject soapObject = (SoapObject) obj;
+     private void writeAttributes(XmlSerializer writer,AttributeContainer obj) throws IOException {
+        AttributeContainer soapObject= (AttributeContainer) obj;
         int cnt = soapObject.getAttributeCount();
         for (int counter = 0; counter < cnt; counter++) {
             AttributeInfo attributeInfo = new AttributeInfo();
             soapObject.getAttributeInfo(counter, attributeInfo);
-            writer.attribute(attributeInfo.getNamespace(), attributeInfo.getName(), attributeInfo.getValue()
-                    .toString());
+            writer.attribute(attributeInfo.getNamespace(), attributeInfo.getName(), attributeInfo.getValue()!=null? attributeInfo.getValue().toString():"");
         }
-        writeObjectBody(writer, (KvmSerializable) obj);
     }
 
+    public void writeObjectBodyWithAttributes(XmlSerializer writer, KvmSerializable obj) throws IOException
+    {
+        if(obj instanceof AttributeContainer)
+        {
+            writeAttributes(writer, (AttributeContainer) obj);
+        }
+        writeObjectBody(writer, obj);
+    }
     /**
      * Writes the body of an KvmSerializable object. This method is public for access from Marshal subclasses.
      */
@@ -622,7 +624,7 @@ public class SoapSerializationEnvelope extends SoapEnvelope
                     String prefix = writer.getPrefix(namespace, true);
                     writer.attribute(xsi, TYPE_LABEL, prefix + ":" + type);
                 }
-                writeObjectBody(writer, nestedSoap);
+                writeObjectBodyWithAttributes(writer, nestedSoap);
                 writer.endTag(namespace, name);
             }
         }
@@ -654,10 +656,8 @@ public class SoapSerializationEnvelope extends SoapEnvelope
             throws IOException {
         if (marshal != null) {
             ((Marshal) marshal).writeInstance(writer, element);
-        } else if (element instanceof SoapObject) {
-            writeObjectBody(writer, (SoapObject) element);
         } else if (element instanceof KvmSerializable) {
-            writeObjectBody(writer, (KvmSerializable) element);
+            writeObjectBodyWithAttributes(writer, (KvmSerializable) element);
         } else if (element instanceof Vector) {
             writeVectorBody(writer, (Vector) element, type.elementType);
         } else {


### PR DESCRIPTION
In the current version, SoapSerializationEnvelope class will serialize attributes only from SoapObject class. The second way of using ksoap2 is to create a custom class which implements KvmSerializable interface. But in our generator (http://easywsdl.com) we sometimes create custom class (with KvmSerializable) and we inherits from AttributeContainer (because some properties must be serialize as attributes). But in the current version of ksoap2 these attributes will not be serialized. 
My refactor allows to serialize attributes from any class which inherits from AttributeContainer
