### PR TITLE
Improvement for extends SoapSerializationEnvelope class

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -650,7 +650,7 @@ public class SoapSerializationEnvelope extends SoapEnvelope
         }
     }
 
-    private void writeElement(XmlSerializer writer, Object element, PropertyInfo type, Object marshal)
+    protected void writeElement(XmlSerializer writer, Object element, PropertyInfo type, Object marshal)
             throws IOException {
         if (marshal != null) {
             ((Marshal) marshal).writeInstance(writer, element);


### PR DESCRIPTION
In http://easywsdl.com generator we inherits from SoapSerializationEnvelope to perform some additional operations. And we invoke writeElement which is private (for now we use reflection to do this). So this refactor will simplify extending envelope class.
