### PR TITLE
Disconnect the HttpURLConnection used by HttpTransportSE

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -274,6 +274,9 @@ public class HttpTransportSE extends Transport {
         // input stream is will be released inside parseResponse
         os = null;
         buf = null;
+        //Disconnecting the connection is required and listed in the android documentation at 
+            //developer.android.com/reference/java/net/HttpURLConnection.html
+        connection.disconnect();
         return retHeaders;
     }
 


### PR DESCRIPTION
Added connection.disconnect() to disconnect the HttpURLConnection used by ServiceConnectionSE. This is documented at developer.android.com/reference/java/net/HttpURLConnection.html. 
