### PR TITLE
Added an inteface HasAttribute which can be used for any class to serial...

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/AttributeContainer.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/AttributeContainer.java
@@ -2,7 +2,7 @@ package org.ksoap2.serialization;
 
 import java.util.Vector;
 
-public class AttributeContainer {
+public class AttributeContainer implements HasAttributes{
     protected Vector attributes = new Vector();
 
     /**

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/HasAttributes.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/HasAttributes.java
@@ -1,0 +1,12 @@
+package org.ksoap2.serialization;
+
+/**
+ * Common inteface for classes which want to serialize attributes to outgoing soap message
+ * @author robocik
+ */
+public interface HasAttributes
+{
+    int getAttributeCount();
+
+    void getAttributeInfo(int index, AttributeInfo info);
+}

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -563,8 +563,8 @@ public class SoapSerializationEnvelope extends SoapEnvelope
         }
     }
 
-     private void writeAttributes(XmlSerializer writer,AttributeContainer obj) throws IOException {
-        AttributeContainer soapObject= (AttributeContainer) obj;
+     private void writeAttributes(XmlSerializer writer,HasAttributes obj) throws IOException {
+         HasAttributes soapObject= (HasAttributes) obj;
         int cnt = soapObject.getAttributeCount();
         for (int counter = 0; counter < cnt; counter++) {
             AttributeInfo attributeInfo = new AttributeInfo();
@@ -576,9 +576,9 @@ public class SoapSerializationEnvelope extends SoapEnvelope
 
     public void writeObjectBodyWithAttributes(XmlSerializer writer, KvmSerializable obj) throws IOException
     {
-        if(obj instanceof AttributeContainer)
+        if(obj instanceof HasAttributes)
         {
-            writeAttributes(writer, (AttributeContainer) obj);
+            writeAttributes(writer, (HasAttributes) obj);
         }
         writeObjectBody(writer, obj);
     }


### PR DESCRIPTION
In EasyWsdl.com we've implemented Array type for RPC encoded web services (more info here http://publib.boulder.ibm.com/infocenter/wmbhelp/v7r0m0/index.jsp?topic=%2Fcom.ibm.etools.mft.doc%2Fbc19050_.htm).
For this we must write some attributes to soap message but we can't inherits from AttributeContainer class (because we already inherits from Vector). With this refactor we can now implement HasAttribute interface and write any attributes we want (AttributeContainer class also implements it).

This refactor is safe and shouldn't break compatibility with any existing code
