### PR TITLE
In RPC encoded arrays we can have multidimentional arrays and in this ca...

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -290,8 +290,15 @@ public class SoapSerializationEnvelope extends SoapEnvelope
         if (value == null) {
             return dflt;
         }
-        return value.length() - start < 3 ? dflt : Integer.parseInt(value.substring(start + 1,
-                value.length() - 1));
+        try
+        {
+            return value.length() - start < 3 ? dflt : Integer.parseInt(value.substring(start + 1,
+                    value.length() - 1));
+        }
+        catch (Exception ex)
+        {
+            return dflt;
+        }
     }
 
     protected void readVector(XmlPullParser parser, Vector v, PropertyInfo elementType) throws IOException,


### PR DESCRIPTION
...se this method throws exception. With this fix ksoap2 uses dynamic size and everything works good.
Basically during our tests we've created web service with RPC encoded style. For one dimentional arrays ksoap2 (getIndex) method works good, but we also have operations which returns arrays with 2 or more dimentions. In this case getIndex method take wrong part of a string and throws exception. With this fix everything works good because ksoap2 uses dynamic size (returns -1).

This change is safe and shouldn't break any existing code
