### PR TITLE
Added feature to control a null value representation in SOAP message

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapPrimitive.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapPrimitive.java
@@ -38,6 +38,9 @@ public class SoapPrimitive extends AttributeContainer {
     protected String name;
     protected Object value;
 
+    public  static final Object NullSkip = new Object();
+    public  static final Object NullNilElement = new Object();
+
     public SoapPrimitive(String namespace, String name, Object value) {
         this.namespace = namespace;
         this.name = name;


### PR DESCRIPTION
In the current version of ksoap2 all null values are serialized in the same way.
- If skipNullProperties is false (default value) then in SOAP body you have nil element.
- If skipNullProperties is true then property with null value will be skipped from SOAP body

The problem is that these behaviors works for ALL properties of any object. But the information if we should add nil element or skip it is in WSDL and there is a big chance that for some properties we should add nil and for the rest we should skip them.

This extension allows you to control how null is serialized. In the default mode (99% cases) code should work the same as in the current version so if property has a null then the serialize behavior is determined based on skipNullProperties.
But if user wants to control this behavior then he can instead of null put one of the two valuses:
- SoapPrimitive.NullSkip - property with this value will be skipped
- SoapPrimitive.NullNilElement - property with this value will be serialized as nil element

Example (part of code generated by http://EasyWSDL.com service):

```
public Boolean Images;    
public Boolean LongTexts;

@Override
public java.lang.Object getProperty(int propertyIndex) {
    if(propertyIndex==0)
    {
        return Images!=null?Images:SoapPrimitive.NullSkip;
    }
    if(propertyIndex==1)
    {
        return LongTexts!=null?LongTexts:SoapPrimitive.NullSkip;
    }
    return null;
}
```

As you see we check if the value of Images is null and if yes the we set a correct null behavior determined from WSDL file.

This change is safe and all existing code should work without any changes.

It would be nice if you make a release with this change because we use changes made in this commit in EasyWSDL.
