### PR TITLE
Fixed HttpsTransportSE#getServiceConnection()

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpsTransportSE.java
@@ -15,6 +15,9 @@ public class HttpsTransportSE extends HttpTransportSE{
 
     static final String PROTOCOL = "https";
     private static final String PROTOCOL_FULL = PROTOCOL + "://";
+	
+	//connection instance, used for setting the SSLSocketFactory
+	private HttpsServiceConnectionSE connection;
 
     protected final String host;
     protected final int port;
@@ -46,8 +49,13 @@ public class HttpsTransportSE extends HttpTransportSE{
      * Returns the HttpsServiceConnectionSE and creates it if necessary
      * @see org.ksoap2.transport.HttpsTransportSE#getServiceConnection()
      */
-    public ServiceConnection getServiceConnection() throws IOException
-    {
-        return new HttpsServiceConnectionSE(proxy, host, port, file, timeout);
-    }
+	public ServiceConnection getServiceConnection() throws IOException
+	{
+		if(connection != null) {
+			return connection;
+		} else {
+			connection = new HttpsServiceConnectionSE(proxy, host, port, file, timeout);
+			return connection;
+		}
+	}
 }


### PR DESCRIPTION
Fixed the issue of not being able to set an SSLSocketFactory using getServiceConnection(), because that method always returned a new instance of ServiceConnection

Issue description:
http://code.google.com/p/ksoap2-android/issues/detail?id=189
