### PR TITLE
HashTable accesible for global namespace prefixes in Transport class

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -23,6 +23,8 @@
 
 package org.ksoap2.transport;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.io.*;
 import java.net.MalformedURLException;
@@ -42,9 +44,9 @@ import org.xmlpull.v1.*;
 abstract public class Transport {
 
     /**
-     * Added to enable web service interactions on the emulator
-     * to be debugged with Fiddler2 (Windows) but provides utility
-     * for other proxy requirements.
+     * Added to enable web service interactions on the emulator to be debugged
+     * with Fiddler2 (Windows) but provides utility for other proxy
+     * requirements.
      */
     protected Proxy proxy;
     protected String url;
@@ -56,13 +58,18 @@ abstract public class Transport {
     /** String dump of response for debugging */
     public String responseDump;
     private String xmlVersionTag = "";
-    
 
     protected static final String CONTENT_TYPE_XML_CHARSET_UTF_8 = "text/xml;charset=utf-8";
     protected static final String CONTENT_TYPE_SOAP_XML_CHARSET_UTF_8 = "application/soap+xml;charset=utf-8";
     protected static final String USER_AGENT = "ksoap2-android/2.6.0+";
 
     private int bufferLength = ServiceConnection.DEFAULT_BUFFER_SIZE;
+
+    private HashMap prefixes = new HashMap();
+
+    public HashMap getPrefixes() {
+        return prefixes;
+    }
 
     public Transport() {
     }
@@ -85,9 +92,12 @@ abstract public class Transport {
     /**
      * Construct the transport object
      * 
-     * @param proxy Specifies the proxy server to use for 
-     * accessing the web service or <code>null</code> if a direct connection is available
-     * @param url Specifies the web service url
+     * @param proxy
+     *            Specifies the proxy server to use for accessing the web
+     *            service or <code>null</code> if a direct connection is
+     *            available
+     * @param url
+     *            Specifies the web service url
      * 
      */
     public Transport(Proxy proxy, String url) {
@@ -111,26 +121,35 @@ abstract public class Transport {
     /**
      * Sets up the parsing to hand over to the envelope to deserialize.
      */
-    protected void parseResponse(SoapEnvelope envelope, InputStream is) throws XmlPullParserException, IOException {
+    protected void parseResponse(SoapEnvelope envelope, InputStream is)
+            throws XmlPullParserException, IOException {
         XmlPullParser xp = new KXmlParser();
         xp.setFeature(XmlPullParser.FEATURE_PROCESS_NAMESPACES, true);
         xp.setInput(is, null);
-        envelope.parse(xp);  
+        envelope.parse(xp);
         /*
          * Fix memory leak when running on android in strict mode. Issue 133
          */
-        is.close();        
+        is.close();
     }
 
     /**
      * Serializes the request.
      */
-    protected byte[] createRequestData(SoapEnvelope envelope, String encoding) throws IOException {
+    protected byte[] createRequestData(SoapEnvelope envelope, String encoding)
+            throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream(bufferLength);
         byte result[] = null;
         bos.write(xmlVersionTag.getBytes());
         XmlSerializer xw = new KXmlSerializer();
+
+        final Iterator keysIter = prefixes.keySet().iterator();
+
         xw.setOutput(bos, encoding);
+        while (keysIter.hasNext()) {
+            String key = (String) keysIter.next();
+            xw.setPrefix(key, (String) prefixes.get(key));
+        }
         envelope.write(xw);
         xw.flush();
         bos.write('\r');
@@ -141,10 +160,12 @@ abstract public class Transport {
         bos = null;
         return result;
     }
+
     /**
      * Serializes the request.
      */
-    protected byte[] createRequestData(SoapEnvelope envelope) throws IOException {
+    protected byte[] createRequestData(SoapEnvelope envelope)
+            throws IOException {
         return createRequestData(envelope, null);
     }
 
@@ -176,44 +197,50 @@ abstract public class Transport {
     }
 
     /**
-     * Perform a soap call with a given namespace and the given envelope providing
-     * any extra headers that the user requires such as cookies. Headers that are
-     * returned by the web service will be returned to the caller in the form of a
-     * <code>List</code> of <code>HeaderProperty</code> instances.
+     * Perform a soap call with a given namespace and the given envelope
+     * providing any extra headers that the user requires such as cookies.
+     * Headers that are returned by the web service will be returned to the
+     * caller in the form of a <code>List</code> of <code>HeaderProperty</code>
+     * instances.
      * 
      * @param soapAction
      *            the namespace with which to perform the call in.
      * @param envelope
      *            the envelope the contains the information for the call.
      * @param headers
-     *   <code>List</code> of <code>HeaderProperty</code> headers to send with the SOAP request.
+     *            <code>List</code> of <code>HeaderProperty</code> headers to
+     *            send with the SOAP request.
      * 
      * @return Headers returned by the web service as a <code>List</code> of
-     * <code>HeaderProperty</code> instances.
+     *         <code>HeaderProperty</code> instances.
      */
-    abstract public List call(String soapAction, SoapEnvelope envelope, List headers)
-            throws IOException, XmlPullParserException;
+    abstract public List call(String soapAction, SoapEnvelope envelope,
+            List headers) throws IOException, XmlPullParserException;
 
     /**
-     * Perform a soap call with a given namespace and the given envelope providing
-     * any extra headers that the user requires such as cookies. Headers that are
-     * returned by the web service will be returned to the caller in the form of a
-     * <code>List</code> of <code>HeaderProperty</code> instances.
-     *
+     * Perform a soap call with a given namespace and the given envelope
+     * providing any extra headers that the user requires such as cookies.
+     * Headers that are returned by the web service will be returned to the
+     * caller in the form of a <code>List</code> of <code>HeaderProperty</code>
+     * instances.
+     * 
      * @param soapAction
      *            the namespace with which to perform the call in.
      * @param envelope
      *            the envelope the contains the information for the call.
      * @param headers
-     *   <code>List</code> of <code>HeaderProperty</code> headers to send with the SOAP request.
+     *            <code>List</code> of <code>HeaderProperty</code> headers to
+     *            send with the SOAP request.
      * @param outputFile
-     *              a file to stream the response into rather than parsing it, streaming happens when file is not null
-     *
+     *            a file to stream the response into rather than parsing it,
+     *            streaming happens when file is not null
+     * 
      * @return Headers returned by the web service as a <code>List</code> of
-     * <code>HeaderProperty</code> instances.
+     *         <code>HeaderProperty</code> instances.
      */
-    abstract public List call(String soapAction, SoapEnvelope envelope, List headers, File outputFile)
-            throws IOException, XmlPullParserException;
+    abstract public List call(String soapAction, SoapEnvelope envelope,
+            List headers, File outputFile) throws IOException,
+            XmlPullParserException;
 
     /**
      * Perform a soap call with a given namespace and the given envelope.
@@ -223,33 +250,35 @@ abstract public class Transport {
      * @param envelope
      *            the envelope the contains the information for the call.
      */
-    public void call(String soapAction, SoapEnvelope envelope) throws IOException, XmlPullParserException {
+    public void call(String soapAction, SoapEnvelope envelope)
+            throws IOException, XmlPullParserException {
         call(soapAction, envelope, null);
-     }
+    }
 
     /**
      * Return the name of the host that is specified as the web service target
-     *
+     * 
      * @return Host name
      */
-    public String getHost()  throws MalformedURLException {
+    public String getHost() throws MalformedURLException {
 
         return new URL(url).getHost();
     }
-        
+
     /**
-     * Return the port number of the host that is specified as the web service target
-     *
+     * Return the port number of the host that is specified as the web service
+     * target
+     * 
      * @return Port number
      */
     public int getPort() throws MalformedURLException {
-        
+
         return new URL(url).getPort();
     }
-        
+
     /**
      * Return the path to the web service target
-     *
+     * 
      * @return The URL's path
      */
     public String getPath() throws MalformedURLException {


### PR DESCRIPTION
This is done specifically for the case of dealing with namespace prefix for attribute value, in case the value and the attribute are not in the same namespace.
