### PR TITLE
Added extensibility points

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -341,6 +341,10 @@ public class SoapSerializationEnvelope extends SoapEnvelope
         parser.require(XmlPullParser.END_TAG, null, null);
     }
 
+    /**
+    * This method returns id from the href attribute value. By default we assume that href value looks like this: #id so we basically have to remove the first character.
+    * But in theory there could be a different value format, like cid:value, etc...
+    */
     protected String getIdFromHref(String hrefValue)
     {
         return hrefValue.substring(1);

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/HttpTransportSE.java
@@ -24,16 +24,11 @@
  * */
 package org.ksoap2.transport;
 
-import com.sun.xml.internal.messaging.saaj.packaging.mime.MessagingException;
-import com.sun.xml.internal.messaging.saaj.packaging.mime.MultipartDataSource;
-import com.sun.xml.internal.messaging.saaj.packaging.mime.internet.MimeMultipart;
-import com.sun.xml.internal.ws.util.ByteArrayDataSource;
 import org.ksoap2.HeaderProperty;
 import org.ksoap2.SoapEnvelope;
 import org.ksoap2.serialization.*;
 import org.xmlpull.v1.XmlPullParserException;
 
-import javax.activation.DataSource;
 import java.io.*;
 import java.net.Proxy;
 import java.util.*;
@@ -307,8 +302,6 @@ public class HttpTransportSE extends Transport {
     {
         return requestData;
     }
-
-
 
     private InputStream readDebug(InputStream is, int contentLength, File outputFile) throws IOException {
         OutputStream bos;


### PR DESCRIPTION
This commit is refactor only (there is no behavior changes and no new features added). We've added some extensibility points to have a possibility to override some methods in our classes generated by http://EasyWSDL.com generator.
Additionally we started to work on MTOM transfer (SOAP with attachments) and those extensibility points allow us inject a new features into ksoap2 library.

We've already tested this commit and all our tests still works good (so existing behavior of ksoap2 hasn't been changed)
