### PR TITLE
Added extensions which allows to customize soap message

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/DM.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/DM.java
@@ -93,9 +93,9 @@ class DM implements Marshal {
             }
         }
 
-        if(instance  instanceof IValueWriter)
+        if(instance  instanceof ValueWriter)
         {
-            ((IValueWriter)instance).write(writer);
+            ((ValueWriter)instance).write(writer);
         }
         else
         {

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/DM.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/DM.java
@@ -92,7 +92,16 @@ class DM implements Marshal {
                 }
             }
         }
-        writer.text(instance.toString());
+
+        if(instance  instanceof IValueWriter)
+        {
+            ((IValueWriter)instance).write(writer);
+        }
+        else
+        {
+            writer.text(instance.toString());
+        }
+
     }
 
     public void register(SoapSerializationEnvelope cm) {

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/HasInnerText.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/HasInnerText.java
@@ -8,10 +8,10 @@ public interface HasInnerText {
      /**
      * Gets the inner text of xml tags
      */
-    String getInnerText();
+    Object getInnerText();
 
     /**
      * @param s String to be set as inner text for an outgoing soap object
      */
-    void setInnerText(String s);
+    void setInnerText(Object s);
 }

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/IValueWriter.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/IValueWriter.java
@@ -1,0 +1,13 @@
+package org.ksoap2.serialization;
+
+import org.xmlpull.v1.XmlSerializer;
+
+import java.io.IOException;
+
+/**
+ * Created by robocik on 2015-09-25.
+ */
+public interface IValueWriter
+{
+    void write(XmlSerializer writer) throws IOException;
+}

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapObject.java
@@ -54,7 +54,7 @@ public class SoapObject extends AttributeContainer implements KvmSerializable, H
      */
     protected Vector properties = new Vector();
 
-    protected String innerText;
+    protected Object innerText;
 
     // TODO: accessing properties and attributes would work much better if we
     // kept a list of known properties instead of iterating through the list
@@ -692,6 +692,17 @@ public class SoapObject extends AttributeContainer implements KvmSerializable, H
         }
     }
 
+    public PropertyInfo getPropertyInfo(int index) {
+        Object element = properties.elementAt(index);
+        if (element instanceof PropertyInfo) {
+            PropertyInfo p = (PropertyInfo) element;
+            return p;
+        } else {
+            // SoapObject
+            return null;
+        }
+    }
+
     /**
      * Creates a new SoapObject based on this, allows usage of SoapObjects as
      * templates. One application is to set the expected return type of a soap
@@ -887,13 +898,17 @@ public class SoapObject extends AttributeContainer implements KvmSerializable, H
         buf.append("}");
         return buf.toString();
     }
-    public String getInnerText() {
+    public Object getInnerText() {
          return innerText;
     }
 
-    public void setInnerText(String innerText)
+    public void setInnerText(Object innerText)
     {
         this.innerText=innerText;
     }
 
+    public void removePropertyInfo(Object info)
+    {
+        properties.remove(info);
+    }
 }

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -27,7 +27,6 @@ import org.xmlpull.v1.XmlPullParserException;
 import org.xmlpull.v1.XmlSerializer;
 
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Vector;
@@ -722,13 +721,26 @@ public class SoapSerializationEnvelope extends SoapEnvelope {
                 writer.endTag(namespace, name);
             }
         }
-        if(obj instanceof HasInnerText){
-            
-        if (((HasInnerText)obj).getInnerText() != null) {
-            writer.cdsect(((HasInnerText)obj).getInnerText());
-        }
-        }
+        writeInnerText(writer, obj);
 
+    }
+
+    private void writeInnerText(XmlSerializer writer, KvmSerializable obj) throws IOException {
+        if(obj instanceof HasInnerText){
+
+            Object value=((HasInnerText)obj).getInnerText();
+            if (value != null) {
+                if(value instanceof IValueWriter)
+                {
+                    ((IValueWriter)value).write(writer);
+                }
+                else
+                {
+                    writer.cdsect(value.toString());
+                }
+
+            }
+        }
     }
 
     protected void writeProperty(XmlSerializer writer, Object obj, PropertyInfo type) throws IOException {
@@ -829,13 +841,7 @@ public class SoapSerializationEnvelope extends SoapEnvelope {
                 writer.endTag(namespace, name);
             }
         }
-        if(obj instanceof HasInnerText){
-        if (((HasInnerText)obj).getInnerText() != null) {
-            writer.cdsect(((HasInnerText)obj).getInnerText());
-
-        }
-        }
-
+        writeInnerText(writer, obj);
     }
 
     protected void writeVectorBody(XmlSerializer writer, Vector vector, PropertyInfo elementType)

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/SoapSerializationEnvelope.java
@@ -730,9 +730,9 @@ public class SoapSerializationEnvelope extends SoapEnvelope {
 
             Object value=((HasInnerText)obj).getInnerText();
             if (value != null) {
-                if(value instanceof IValueWriter)
+                if(value instanceof ValueWriter)
                 {
-                    ((IValueWriter)value).write(writer);
+                    ((ValueWriter)value).write(writer);
                 }
                 else
                 {

--- a/ksoap2-base/src/main/java/org/ksoap2/serialization/ValueWriter.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/serialization/ValueWriter.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 /**
  * Created by robocik on 2015-09-25.
  */
-public interface IValueWriter
+public interface ValueWriter
 {
     void write(XmlSerializer writer) throws IOException;
 }


### PR DESCRIPTION
Small refactor which adds some extensibility points. Can be used to modify (customize) soap raw message. New code has been tested with our internal tests in EasyWSDL. There is a small breaking change. Basically setInnerText and getInnerText methods now take/return Object instead of String type. But these methods are in a separate interface and probably the usage of them is very little. Fixing the code to use new methods are very easy.