### PR TITLE
Excluding XML Pull Parser dependency from Android's artifact

### DIFF
--- a/ksoap2-android/pom.xml
+++ b/ksoap2-android/pom.xml
@@ -21,6 +21,13 @@
         <dependency>
             <groupId>com.google.code.ksoap2-android</groupId>
             <artifactId>ksoap2-j2se</artifactId>
+            <exclusions>
+            	<!-- XML Pull Parser is already packed in Android's framework and will cause conflicts -->
+            	<exclusion>
+            		<groupId>org.xmlpull</groupId>
+            		<artifactId>xmlpull</artifactId>
+            	</exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Will conflict with Android framework and ProGuard will refuse it. This change removes the dependency on xmlpull.