### PR TITLE
Allow to specify an existing OkHttpClient instance for transport

### DIFF
--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpServiceConnectionSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpServiceConnectionSE.java
@@ -51,10 +51,15 @@ public class OkHttpServiceConnectionSE implements ServiceConnection {
     }
 
     public OkHttpServiceConnectionSE(Proxy proxy, String url, int timeout) throws IOException {
-        client = new OkHttpClient.Builder()
+        this(new OkHttpClient.Builder()
                 .connectTimeout(timeout, TimeUnit.MILLISECONDS)
                 .readTimeout(timeout, TimeUnit.MILLISECONDS)
-                .build();
+                .build(),
+             proxy, url, timeout);
+    }      
+                
+    public OkHttpServiceConnectionSE(OkHttpClient client, Proxy proxy, String url, int timeout) throws IOException {
+        this.client = client;
         connection = new HttpURLConnectionImpl(new URL(url), client);
 //        connection = (proxy == null)
 //                ? new HttpURLConnectionImpl(new URL(url), client)

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpTransportSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpTransportSE.java
@@ -2,6 +2,7 @@ package org.ksoap2.transport;
 
 import java.io.IOException;
 import java.net.Proxy;
+import okhttp3.OkHttpClient;
 
 /**
  * A simple Transport based on OkHttp3's URLConnection implementation
@@ -9,32 +10,50 @@ import java.net.Proxy;
  * ref. https://code.google.com/p/android/issues/detail?id=40874
  */
 public class OkHttpTransportSE extends HttpTransportSE {
+
+    protected final OkHttpClient client;
+
     public OkHttpTransportSE(Proxy proxy, String url) {
         super(proxy, url);
+        this.client = null;
     }
 
     public OkHttpTransportSE(Proxy proxy, String url, int timeout) {
         super(proxy, url, timeout);
+        this.client = null;
     }
 
     public OkHttpTransportSE(Proxy proxy, String url, int timeout, int contentLength) {
         super(proxy, url, timeout, contentLength);
+        this.client = null;
+    }
+
+    public OkHttpTransportSE(OkHttpClient client, Proxy proxy, String url, int timeout, int contentLength) {
+        super(proxy, url, timeout, contentLength);
+        this.client = client;
     }
 
     public OkHttpTransportSE(String url) {
         super(url);
+        this.client = null;
     }
 
     public OkHttpTransportSE(String url, int timeout) {
         super(url, timeout);
+        this.client = null;
     }
 
     public OkHttpTransportSE(String url, int timeout, int contentLength) {
         super(url, timeout, contentLength);
+        this.client = null;
     }
 
     @Override
     public ServiceConnection getServiceConnection() throws IOException {
-        return new OkHttpServiceConnectionSE(proxy, url, timeout);
+        if (client == null) {
+            return new OkHttpServiceConnectionSE(proxy, url, timeout);
+        } else {
+            return new OkHttpServiceConnectionSE(client, proxy, url, timeout);
+        }
     }
 }


### PR DESCRIPTION
When using OkHttp as transport it is a bad idea to use a fixed OkHttpClient as all configuration is fixed and can not be changed (e.g. authenticators). 

Therefore I added a new constructor in 	OkHttpTransportSE and OkHttpServiceConnectionSE that allows to specify an existing OkHttpClient instance.