### PR TITLE
J2SE: Update OkHttp to 3.12

### DIFF
--- a/ksoap2-j2se/pom.xml
+++ b/ksoap2-j2se/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
-            <version>3.2.0</version>
+            <version>3.12.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpServiceConnectionSE.java
+++ b/ksoap2-j2se/src/main/java/org/ksoap2/transport/OkHttpServiceConnectionSE.java
@@ -1,5 +1,7 @@
 package org.ksoap2.transport;
 
+import okhttp3.OkHttpClient;
+import okhttp3.internal.huc.OkHttpURLConnection;
 import org.ksoap2.HeaderProperty;
 
 import java.io.IOException;
@@ -8,15 +10,8 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.Proxy;
 import java.net.URL;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
-
-import okhttp3.OkHttpClient;
-import okhttp3.internal.huc.HttpURLConnectionImpl;
 
 /**
  * A simple ServiceConnection based on OkHttp3's URLConnection implementation
@@ -60,7 +55,7 @@ public class OkHttpServiceConnectionSE implements ServiceConnection {
                 
     public OkHttpServiceConnectionSE(OkHttpClient client, Proxy proxy, String url, int timeout) throws IOException {
         this.client = client;
-        connection = new HttpURLConnectionImpl(new URL(url), client);
+        connection = new OkHttpURLConnection(new URL(url), client);
 //        connection = (proxy == null)
 //                ? new HttpURLConnectionImpl(new URL(url), client)
 //                : (HttpURLConnectionImpl) new URL(url).openConnection(proxy);

--- a/ksoap2-okhttp/pom.xml
+++ b/ksoap2-okhttp/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
-            <version>3.12.0</version>
+            <version>3.12.1</version>
         </dependency>
         <dependency>
             <groupId>jcifs</groupId>


### PR DESCRIPTION
Some applications might use conflicting versions of OkHttp. In that case update OkHttp in the J2SE module so we can still benefit from the latest features