### PR TITLE
Fix transport timeout not considered

### DIFF
--- a/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
+++ b/ksoap2-base/src/main/java/org/ksoap2/transport/Transport.java
@@ -86,6 +86,7 @@ abstract public class Transport {
     public Transport(String url, int timeout) {
         this.url = url;
         this.timeout = timeout;
+        this.readTimeout = timeout;
     }
 
     public Transport(String url, int timeout, int bufferLength) {


### PR DESCRIPTION
Small fix to consider the timeout in all constructors of Transport class

Fix #131 